### PR TITLE
Update CI site owner detection

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -5,11 +5,14 @@ import tailwindcss from '@tailwindcss/vite';
 // Project Pages: https://<user>.github.io/recruit-lp/
 const repoName = 'recruit-lp';
 const isCI = process.env.CI === 'true';
+const repoOwner =
+  process.env.GITHUB_REPOSITORY_OWNER ??
+  process.env.GITHUB_REPOSITORY?.split('/')[0];
 // https://astro.build/config
 export default defineConfig({
   vite: {
     plugins: [tailwindcss()],
   },
-  site: isCI ? `https://${process.env.GITHUB_OWNER}.github.io` : 'http://localhost:4321',
+  site: isCI && repoOwner ? `https://${repoOwner}.github.io` : 'http://localhost:4321',
   base: isCI ? `/${repoName}/` : '/',
 });


### PR DESCRIPTION
### Motivation
- Ensure the `site` config for GitHub Pages in CI builds uses the actual repository owner by deriving it from `GITHUB_REPOSITORY_OWNER` or `GITHUB_REPOSITORY`, removing reliance on the non-standard `GITHUB_OWNER`.

### Description
- Add `repoOwner` computed from `process.env.GITHUB_REPOSITORY_OWNER` or `process.env.GITHUB_REPOSITORY?.split('/')[0]`.
- Update `site` to use `repoOwner` when `isCI` is true and fall back to `http://localhost:4321`.
- Preserve existing `base` behavior and the `repoName` constant while removing the direct use of `process.env.GITHUB_OWNER`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696adef0cc948321bd17df2a00eaad7f)