### PR TITLE
Use settings entry by slug in index page

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,7 +1,7 @@
 ---
 import '../styles/global.css';
 import LinkSection from '../components/LinkSection.astro';
-import { getCollection } from 'astro:content';
+import { getCollection, getEntryBySlug } from 'astro:content';
 
 const links = await getCollection('links');
 const jobboards = links.find((x) => x.slug === 'jobboards');
@@ -11,8 +11,8 @@ if (!jobboards || !wantedly) {
   throw new Error('必要なリンクコンテンツが見つかりません');
 }
 
-const settingsCol = await getCollection('settings');
-const settings = settingsCol[0]?.data;
+const settingsEntry = await getEntryBySlug('settings', 'settings');
+const settings = settingsEntry?.data;
 if (!settings) {
   throw new Error('設定ファイルが見つかりません');
 }


### PR DESCRIPTION
### Motivation
- Ensure the page only reads the intended settings file by using an explicit slug lookup instead of scanning the whole `settings` collection, avoiding accidental selection of the wrong file.

### Description
- Import `getEntryBySlug` from `astro:content` and replace `getCollection('settings')` + indexing with `getEntryBySlug('settings', 'settings')`, then use `settingsEntry?.data` for downstream values.

### Testing
- No automated tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696adf3300c88321b19d938a03d19834)