### PR TITLE
Split index page into HeroSection and PageBackground components

### DIFF
--- a/src/components/HeroSection.astro
+++ b/src/components/HeroSection.astro
@@ -1,0 +1,63 @@
+---
+type HeroData = {
+  headline: string;
+  subcopy?: string;
+};
+
+type Props = {
+  hero: HeroData;
+  features: string[];
+};
+
+const { hero, features } = Astro.props;
+---
+
+<header
+  class="relative overflow-hidden rounded-3xl border border-slate-200 bg-white/55 p-6 backdrop-blur sm:p-10"
+>
+  <!-- 追加の薄い演出 -->
+  <div class="pointer-events-none absolute inset-0">
+    <div
+      class="absolute -top-20 left-1/2 h-72 w-72 -translate-x-1/2 rounded-full bg-sky-200/35 blur-3xl"
+    >
+    </div>
+    <div class="absolute top-8 right-8 h-72 w-72 rounded-full bg-emerald-200/25 blur-3xl">
+    </div>
+  </div>
+
+  <div class="relative">
+    <div class="flex items-center justify-between gap-4">
+      <img
+        src={`${import.meta.env.BASE_URL}logo.svg`}
+        class="h-16 w-auto"
+        alt="株式会社日本オーエー研究所"
+      />
+    </div>
+
+    <h1 class="mt-6 text-[clamp(1rem,3cqw,3rem)] font-semibold tracking-tight text-slate-900">
+      <span class="bg-gradient-to-r from-sky-600 to-emerald-600 bg-clip-text text-transparent">
+        {hero.headline}
+      </span>
+    </h1>
+
+    {
+      hero.subcopy && (
+        <p class="mt-4 max-w-3xl text-base leading-relaxed text-slate-600 sm:text-lg">
+          {hero.subcopy}
+        </p>
+      )
+    }
+
+    {
+      features.length > 0 && (
+        <div class="mt-6 flex flex-wrap gap-2">
+          {features.map((t) => (
+            <span class="rounded-full bg-white/70 px-3 py-1 text-xs font-medium text-slate-700 ring-1 ring-slate-200">
+              {t}
+            </span>
+          ))}
+        </div>
+      )
+    }
+  </div>
+</header>

--- a/src/components/PageBackground.astro
+++ b/src/components/PageBackground.astro
@@ -1,0 +1,10 @@
+<div class="pointer-events-none fixed inset-0 -z-10">
+  <div
+    class="absolute -left-[200px] -top-[200px] h-[520px] w-[520px] rounded-full bg-sky-300/20 blur-3xl"
+  >
+  </div>
+  <div
+    class="absolute -right-[220px] top-20 h-[520px] w-[520px] rounded-full bg-emerald-300/20 blur-3xl"
+  >
+  </div>
+</div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,6 +1,8 @@
 ---
 import '../styles/global.css';
+import HeroSection from '../components/HeroSection.astro';
 import LinkSection from '../components/LinkSection.astro';
+import PageBackground from '../components/PageBackground.astro';
 import { getCollection, getEntryBySlug } from 'astro:content';
 
 const links = await getCollection('links');
@@ -65,70 +67,9 @@ const heroFeatures: string[] = hero?.features ?? [];
 
   <body class="min-h-screen bg-slate-50 text-slate-900">
     <main class="mx-auto max-w-5xl px-4 py-10">
-      <!-- 背景 -->
-      <div class="pointer-events-none fixed inset-0 -z-10">
-        <div
-          class="absolute -left-[200px] -top-[200px] h-[520px] w-[520px] rounded-full bg-sky-300/20 blur-3xl"
-        >
-        </div>
-        <div
-          class="absolute -right-[220px] top-20 h-[520px] w-[520px] rounded-full bg-emerald-300/20 blur-3xl"
-        >
-        </div>
-      </div>
+      <PageBackground />
 
-      <!-- Hero -->
-      <header
-        class="relative overflow-hidden rounded-3xl border border-slate-200 bg-white/55 p-6 backdrop-blur sm:p-10"
-      >
-        <!-- 追加の薄い演出 -->
-        <div class="pointer-events-none absolute inset-0">
-          <div
-            class="absolute -top-20 left-1/2 h-72 w-72 -translate-x-1/2 rounded-full bg-sky-200/35 blur-3xl"
-          >
-          </div>
-          <div class="absolute top-8 right-8 h-72 w-72 rounded-full bg-emerald-200/25 blur-3xl">
-          </div>
-        </div>
-
-        <div class="relative">
-          <div class="flex items-center justify-between gap-4">
-            <img
-              src={`${import.meta.env.BASE_URL}logo.svg`}
-              class="h-16 w-auto"
-              alt="株式会社日本オーエー研究所"
-            />
-          </div>
-
-          <h1 class="mt-6 text-[clamp(1rem,3cqw,3rem)] font-semibold tracking-tight text-slate-900">
-            <span
-              class="bg-gradient-to-r from-sky-600 to-emerald-600 bg-clip-text text-transparent"
-            >
-              {hero.headline}
-            </span>
-          </h1>
-
-          {
-            hero.subcopy && (
-              <p class="mt-4 max-w-3xl text-base leading-relaxed text-slate-600 sm:text-lg">
-                {hero.subcopy}
-              </p>
-            )
-          }
-
-          {
-            heroFeatures.length > 0 && (
-              <div class="mt-6 flex flex-wrap gap-2">
-                {heroFeatures.map((t) => (
-                  <span class="rounded-full bg-white/70 px-3 py-1 text-xs font-medium text-slate-700 ring-1 ring-slate-200">
-                    {t}
-                  </span>
-                ))}
-              </div>
-            )
-          }
-        </div>
-      </header>
+      <HeroSection hero={hero} features={heroFeatures} />
 
       <!-- Sections -->
       <div class="mt-8 space-y-8">


### PR DESCRIPTION
### Motivation
- Modularize the large `index.astro` file by extracting distinct UI parts into components for reuse and clearer structure.
- Reduce duplication and make the page layout easier to reason about and maintain.
- Prepare for easier future styling and behavior changes by isolating the hero and background pieces.

### Description
- Added `src/components/HeroSection.astro` which encapsulates the hero header markup and exposes typed props `hero` and `features`.
- Added `src/components/PageBackground.astro` which contains the fixed blurred background markup.
- Updated `src/pages/index.astro` to import and use `HeroSection` and `PageBackground`, removing the previously inlined hero and background markup.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ae08f55108321ad4e7d79077d2b32)