### PR TITLE
Adjust palette to highlight logo green

### DIFF
--- a/src/components/HeroSection.astro
+++ b/src/components/HeroSection.astro
@@ -14,15 +14,15 @@ const headlineLines = hero.headline.split('\n');
 ---
 
 <header
-  class="relative overflow-hidden rounded-3xl border border-slate-200 bg-white/55 p-6 backdrop-blur sm:p-10"
+  class="relative overflow-hidden rounded-3xl border border-emerald-100/70 bg-white/75 p-6 backdrop-blur sm:p-10"
 >
   <!-- 追加の薄い演出 -->
   <div class="pointer-events-none absolute inset-0">
     <div
-      class="absolute -top-20 left-1/2 h-72 w-72 -translate-x-1/2 rounded-full bg-sky-200/35 blur-3xl"
+      class="absolute -top-20 left-1/2 h-72 w-72 -translate-x-1/2 rounded-full bg-sky-200/45 blur-3xl"
     >
     </div>
-    <div class="absolute top-8 right-8 h-72 w-72 rounded-full bg-emerald-200/25 blur-3xl"></div>
+    <div class="absolute top-8 right-8 h-72 w-72 rounded-full bg-emerald-200/40 blur-3xl"></div>
   </div>
 
   <div class="relative space-y-6">
@@ -41,7 +41,7 @@ const headlineLines = hero.headline.split('\n');
         <span
           class={`block ${
             index === 0
-              ? 'bg-gradient-to-r from-sky-600 to-emerald-600 bg-clip-text text-transparent font-semibold'
+              ? 'bg-gradient-to-r from-emerald-600 via-emerald-500 to-sky-500 bg-clip-text text-transparent font-semibold'
               : 'mt-1 text-[0.78em] leading-snug text-slate-600 sm:text-[0.72em] sm:leading-tight'
           }`}
         >
@@ -62,7 +62,7 @@ const headlineLines = hero.headline.split('\n');
       features.length > 0 && (
         <div class="mt-6 flex flex-wrap gap-2 sm:mt-8 sm:gap-3">
           {features.map((t) => (
-            <span class="rounded-full border border-sky-300/80 bg-gradient-to-r from-white to-sky-100 px-3 py-1.5 text-xs font-semibold text-slate-700 shadow-[0_8px_18px_rgba(14,116,144,0.18)] ring-1 ring-sky-100/80 sm:px-4 sm:py-2 sm:text-sm">
+            <span class="rounded-full border border-emerald-200/80 bg-gradient-to-r from-white via-emerald-50 to-emerald-100 px-3 py-1.5 text-xs font-semibold text-emerald-900 shadow-[0_8px_18px_rgba(16,185,129,0.18)] ring-1 ring-emerald-100/80 sm:px-4 sm:py-2 sm:text-sm">
               {t}
             </span>
           ))}

--- a/src/components/LinkSection.astro
+++ b/src/components/LinkSection.astro
@@ -30,31 +30,31 @@ const isMuted = sectionVariant === 'muted';
 const countBadgeClass = [
   'shrink-0 rounded-full px-3 py-1 text-xs font-semibold ring-1 flex items-center gap-2 tabular-nums',
   isHighlight
-    ? 'bg-sky-100 text-sky-700 ring-sky-200'
+    ? 'bg-emerald-100/80 text-emerald-800 ring-emerald-200'
     : isMuted
       ? 'bg-slate-100 text-slate-500 ring-slate-200'
-      : 'bg-sky-50 text-sky-700 ring-sky-200',
+      : 'bg-emerald-50 text-emerald-700 ring-emerald-200',
 ].join(' ');
 
 const cardBaseClass = [
-  'group block rounded-xl border bg-white/80 p-4 transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-300',
+  'group block rounded-xl border bg-white/85 p-4 transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-300',
   isHighlight
-    ? 'border-sky-200 bg-white shadow-[0_12px_28px_rgba(14,116,144,0.14)] hover:border-sky-400 hover:bg-sky-50/80 hover:shadow-[0_16px_34px_rgba(14,116,144,0.18)]'
+    ? 'border-emerald-200/80 bg-white shadow-[0_12px_28px_rgba(16,185,129,0.12)] hover:border-emerald-300 hover:bg-emerald-50/70 hover:shadow-[0_16px_34px_rgba(16,185,129,0.16)]'
     : isMuted
       ? 'border-slate-100 bg-slate-50/70 hover:border-slate-300 hover:bg-white/80 hover:shadow-sm'
-      : 'border-slate-100 hover:border-sky-400 hover:bg-sky-50/70 hover:shadow-sm',
+      : 'border-slate-100 hover:border-emerald-300 hover:bg-emerald-50/60 hover:shadow-sm',
 ].join(' ');
 
 const labelClass =
-  'truncate font-semibold text-slate-900 transition-colors group-hover:text-sky-600 group-hover:underline group-hover:underline-offset-4';
+  'truncate font-semibold text-slate-900 transition-colors group-hover:text-emerald-700 group-hover:underline group-hover:underline-offset-4';
 const metaTextClass = isHighlight ? 'text-slate-500' : 'text-slate-400';
-const arrowClass = 'mt-0.5 text-base text-slate-500 transition group-hover:text-sky-600';
+const arrowClass = 'mt-0.5 text-base text-slate-500 transition group-hover:text-emerald-600';
 ---
 
 <section
   class={`rounded-2xl border p-5 sm:p-6 shadow-[0_20px_40px_rgba(15,23,42,0.08)] backdrop-blur ${
     sectionVariant === 'highlight'
-      ? 'border-sky-200/70 bg-slate-50/60 shadow-[0_18px_32px_rgba(14,116,144,0.12)]'
+      ? 'border-emerald-200/70 bg-emerald-50/40 shadow-[0_18px_32px_rgba(16,185,129,0.12)]'
       : isMuted
         ? 'border-slate-200 bg-slate-50/80'
         : 'border-slate-200 bg-white/80'
@@ -75,7 +75,7 @@ const arrowClass = 'mt-0.5 text-base text-slate-500 transition group-hover:text-
 
   {
     visibleItems.length === 0 ? (
-      <div class="rounded-xl border border-slate-200 bg-slate-50 p-4 text-sm text-slate-600">
+      <div class="rounded-xl border border-slate-200 bg-white/80 p-4 text-sm text-slate-600">
         現在、募集中の求人はありません。
       </div>
     ) : (
@@ -100,13 +100,13 @@ const arrowClass = 'mt-0.5 text-base text-slate-500 transition group-hover:text-
                       {it.tags.map((tag) => (
                         <span
                           class="inline-flex items-center rounded-full
-               border border-sky-200
-               bg-sky-50
+               border border-emerald-200
+               bg-emerald-50
                px-2.5 py-0.5
-               text-xs font-medium text-sky-800
+               text-xs font-medium text-emerald-800
                transition
-               group-hover:border-sky-300
-               group-hover:bg-sky-100"
+               group-hover:border-emerald-300
+               group-hover:bg-emerald-100"
                         >
                           {tag}
                         </span>

--- a/src/components/PageBackground.astro
+++ b/src/components/PageBackground.astro
@@ -1,10 +1,10 @@
 <div class="pointer-events-none fixed inset-0 -z-10">
   <div
-    class="absolute -left-[200px] -top-[200px] h-[520px] w-[520px] rounded-full bg-sky-300/20 blur-3xl"
+    class="absolute -left-[200px] -top-[200px] h-[520px] w-[520px] rounded-full bg-sky-200/35 blur-3xl"
   >
   </div>
   <div
-    class="absolute -right-[220px] top-20 h-[520px] w-[520px] rounded-full bg-emerald-300/20 blur-3xl"
+    class="absolute -right-[220px] top-20 h-[520px] w-[520px] rounded-full bg-emerald-200/35 blur-3xl"
   >
   </div>
 </div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -85,7 +85,7 @@ const currentYear = new Date().getFullYear();
       </div>
     </main>
 
-    <footer class="border-t border-slate-200/80 bg-white/70 backdrop-blur">
+    <footer class="border-t border-emerald-100/80 bg-white/80 backdrop-blur">
       <div
         class="mx-auto flex max-w-5xl flex-col gap-4 px-4 py-6 text-sm text-slate-600 sm:flex-row sm:items-center sm:justify-between"
       >
@@ -95,19 +95,19 @@ const currentYear = new Date().getFullYear();
         </div>
         <nav class="flex flex-wrap items-center gap-4 text-base text-slate-700">
           <a
-            class="rounded-full px-4 py-2 text-base font-medium tracking-wide text-slate-600 transition-colors hover:text-sky-600 hover:bg-sky-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-400"
+            class="rounded-full px-4 py-2 text-base font-medium tracking-wide text-slate-600 transition-colors hover:text-emerald-700 hover:bg-emerald-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-400"
             href="#jobboards"
           >
             求人情報
           </a>
           <a
-            class="rounded-full px-4 py-2 text-base font-medium tracking-wide text-slate-600 transition-colors hover:text-sky-600 hover:bg-sky-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-400"
+            class="rounded-full px-4 py-2 text-base font-medium tracking-wide text-slate-600 transition-colors hover:text-emerald-700 hover:bg-emerald-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-400"
             href="#wantedly"
           >
             Wantedly
           </a>
           <a
-            class="rounded-full px-4 py-2 text-base font-medium tracking-wide text-slate-600 transition-colors hover:text-sky-600 hover:bg-sky-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-400"
+            class="rounded-full px-4 py-2 text-base font-medium tracking-wide text-slate-600 transition-colors hover:text-emerald-700 hover:bg-emerald-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-400"
             href="#"
           >
             トップへ


### PR DESCRIPTION
### Motivation
- Make the site feel brighter and more refined while letting the logo green stand out. 
- Move various highlight/interactive accents from blue (`sky`) to emerald to create a cohesive brand accent. 

### Description
- Updated background glow tones in `src/components/PageBackground.astro` to lighter sky and emerald hues. 
- Tweaked `src/components/HeroSection.astro` to brighten the hero panel (`border`/`bg`), intensify glow layers, and change the headline gradient and feature badges to emerald-forward colors. 
- Converted highlight styles in `src/components/LinkSection.astro` from sky to emerald for badges, cards, tags, label hover, and arrow accents, and adjusted the highlighted section background. 
- Adjusted footer border and link hover/focus colors in `src/pages/index.astro` to use emerald tones. 

### Testing
- Started the dev server with `pnpm dev` and confirmed the app served (server reported ready). 
- Performed a basic HTTP smoke-check with `curl -I http://localhost:4321` which returned `HTTP/1.1 200 OK`. 
- Attempted an automated visual snapshot via Playwright to verify rendering but the run failed with `net::ERR_EMPTY_RESPONSE`, so visual regression capture did not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b1e796f688321b016db44ac123456)