### PR TITLE
Fix absolute OG image URL

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -25,6 +25,7 @@ const pageDesc = settings.site.description;
 const ogTitle = settings.site.og?.title ?? pageTitle;
 const ogDesc = settings.site.og?.description ?? pageDesc;
 const ogImage = settings.site.og?.image;
+const ogImageUrl = ogImage ? new URL(ogImage, Astro.site).toString() : undefined;
 
 const twCard = settings.site.twitter?.card ?? 'summary';
 const twSite = settings.site.twitter?.site;
@@ -51,7 +52,7 @@ const currentYear = new Date().getFullYear();
     <meta property="og:type" content="website" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
-    {ogImage && <meta property="og:image" content={`${import.meta.env.BASE_URL}${ogImage}`} />}
+    {ogImageUrl && <meta property="og:image" content={ogImageUrl} />}
 
     <meta name="twitter:card" content={twCard} />
     {twSite && <meta name="twitter:site" content={twSite} />}


### PR DESCRIPTION
### Motivation
- Ensure the `og:image` meta tag uses an absolute URL based on the site origin (`Astro.site`) rather than concatenating with `import.meta.env.BASE_URL`, which can produce incorrect URLs.

### Description
- Compute `ogImageUrl` with `new URL(ogImage, Astro.site).toString()` and use it for the `og:image` meta tag in `src/pages/index.astro`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b84f4e2608321b4f559143a0cbc3e)