### PR TITLE
Fix OG/Twitter image URLs and guard missing image

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -34,7 +34,9 @@ const hero = settings.hero;
 const heroFeatures: string[] = hero?.features ?? [];
 const companyName = settings.brand?.companyName ?? pageTitle;
 const currentYear = new Date().getFullYear();
-const siteUrl = import.meta.env.BASE_URL;
+const baseUrl = import.meta.env.BASE_URL;
+const siteUrl = Astro.site ? new URL(baseUrl, Astro.site).toString() : baseUrl;
+const ogImageUrl = ogImage ? new URL(ogImage, siteUrl).toString() : undefined;
 ---
 
 <!doctype html>
@@ -54,10 +56,10 @@ const siteUrl = import.meta.env.BASE_URL;
     <meta property="og:type" content="website" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
-    {ogImage && <meta property="og:image" content={`${siteUrl}${ogImage}`} />}
+    {ogImageUrl && <meta property="og:image" content={ogImageUrl} />}
 
     <meta name="twitter:card" content={twCard} />
-    <meta name="twitter:image" content={`${siteUrl}${ogImage}`} />
+    {ogImageUrl && <meta name="twitter:image" content={ogImageUrl} />}
     {twSite && <meta name="twitter:site" content={twSite} />}
     {twCreator && <meta name="twitter:creator" content={twCreator} />}
 


### PR DESCRIPTION
### Motivation
- Ensure OG/Twitter image tags use absolute, deployable URLs and avoid emitting `undefined` when no OG image is configured.

### Description
- Update `src/pages/index.astro` to build `siteUrl` from `Astro.site` and `import.meta.env.BASE_URL`, and derive `ogImageUrl` via `new URL(ogImage, siteUrl)`.
- Replace interpolated `${siteUrl}${ogImage}` usage with `ogImageUrl` and conditionally render `og:image` and `twitter:image` only when `ogImageUrl` is present.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b891d739883218f2840259a674c70)