### PR TITLE
Update site URL for new domain

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -14,10 +14,6 @@ export default defineConfig({
   vite: {
     plugins: [tailwindcss()],
   },
-  site: isCI
-    ? repoOwner
-      ? `https://${repoOwner}.github.io`
-      : `https://${repoName}.github.io`
-    : 'http://localhost:4321',
-  base: isCI ? (isUserPages ? '/' : `/${repoName}/`) : '/',
+  site: isCI ? 'https://mcr.noar.biz' : 'http://localhost:4321',
+  base: '/',
 });


### PR DESCRIPTION
### Motivation

- Set the Astro `site` URL to the new production domain and simplify base path handling for CI and local development.

### Description

- In `astro.config.mjs` replace the previous GitHub Pages detection with a fixed `site` value of `'https://mcr.noar.biz'` when `CI` is true and set `base` to `'/'`, removing the conditional GitHub Pages logic.

### Testing

- No automated tests were run; this is a config-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696da259a19c832187abbda588b3a8fe)