### PR TITLE
Use PUBLIC_SITE_URL (HTTPS) for Astro site to fix OG image URLs

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -4,16 +4,16 @@ import { defineConfig } from 'astro/config';
 import tailwindcss from '@tailwindcss/vite';
 // Project Pages: https://<owner>.github.io/<repo>/ or User/Org Pages: https://<owner>.github.io/
 const repoName = process.env.GITHUB_REPOSITORY?.split('/')[1] ?? 'recruit-lp';
-const isCI = process.env.CI === 'true';
 const repoOwner =
   process.env.GITHUB_REPOSITORY_OWNER ??
   process.env.GITHUB_REPOSITORY?.split('/')[0];
 const isUserPages = Boolean(repoOwner && repoName === `${repoOwner}.github.io`);
+const siteUrl = process.env.PUBLIC_SITE_URL ?? 'https://mcr.noar.biz';
 // https://astro.build/config
 export default defineConfig({
   vite: {
     plugins: [tailwindcss()],
   },
-  site: isCI ? 'https://mcr.noar.biz' : 'http://localhost:4321',
+  site: siteUrl,
   base: '/',
 });


### PR DESCRIPTION
### Motivation
- OG image URLs were resolving to an insecure host when not running in CI, causing "保護されていない" warnings, so the site URL used to build absolute OG image links must default to an HTTPS host.

### Description
- Update `astro.config.mjs` to remove the CI-only `isCI` switch and instead set `site` from `process.env.PUBLIC_SITE_URL` with a default of `https://mcr.noar.biz`, so OG image URLs are generated over HTTPS by default.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696da42c9c74832195bfd5402fd5dc95)