### PR TITLE
Add HTTPS redirect for mcr.noar.biz

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1,0 +1,1 @@
+http://mcr.noar.biz/* https://mcr.noar.biz/:splat 301!


### PR DESCRIPTION
### Motivation
- Force all `http://mcr.noar.biz` traffic to use HTTPS by adding a redirect rule for the site.

### Description
- Add a Netlify-style redirects file `public/_redirects` containing the rule `http://mcr.noar.biz/* https://mcr.noar.biz/:splat 301!` to permanently redirect HTTP to HTTPS.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696da589e0a8832197c6a012468a3820)