### PR TITLE
Remove unused GitHub Pages flag and mark analytics scripts inline

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -7,7 +7,6 @@ const repoName = process.env.GITHUB_REPOSITORY?.split('/')[1] ?? 'recruit-lp';
 const repoOwner =
   process.env.GITHUB_REPOSITORY_OWNER ??
   process.env.GITHUB_REPOSITORY?.split('/')[0];
-const isUserPages = Boolean(repoOwner && repoName === `${repoOwner}.github.io`);
 const siteUrl = process.env.PUBLIC_SITE_URL ?? 'https://mcr.noar.biz';
 // https://astro.build/config
 export default defineConfig({

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -43,8 +43,8 @@ const ogImageUrl = ogImage ? new URL(ogImage, siteUrl).toString() : undefined;
 <html lang="ja">
   <head>
     <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-2V244B0FGZ"></script>
-    <script defer src="/gtag-init.js"></script>
+    <script is:inline async src="https://www.googletagmanager.com/gtag/js?id=G-2V244B0FGZ"></script>
+    <script is:inline defer src="/gtag-init.js"></script>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width,initial-scale=1" />
     <title>{pageTitle}</title>


### PR DESCRIPTION
### Motivation
- Remove the unused `isUserPages` variable to silence Astro config lint/hint warnings and explicitly mark analytics scripts as inline to satisfy Astro's script handling hints.

### Description
- Deleted the unused `isUserPages` declaration from `astro.config.mjs`.
- Added `is:inline` attributes to the Google Tag Manager script and the local `gtag-init.js` script in `src/pages/index.astro`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ef31cdb708321a9a543e99873cba0)