### PR TITLE
Remove unused repo variables from Astro config

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -2,11 +2,6 @@
 import { defineConfig } from 'astro/config';
 
 import tailwindcss from '@tailwindcss/vite';
-// Project Pages: https://<owner>.github.io/<repo>/ or User/Org Pages: https://<owner>.github.io/
-const repoName = process.env.GITHUB_REPOSITORY?.split('/')[1] ?? 'recruit-lp';
-const repoOwner =
-  process.env.GITHUB_REPOSITORY_OWNER ??
-  process.env.GITHUB_REPOSITORY?.split('/')[0];
 const siteUrl = process.env.PUBLIC_SITE_URL ?? 'https://mcr.noar.biz';
 // https://astro.build/config
 export default defineConfig({


### PR DESCRIPTION
### Motivation
- Remove unused `repoName` and `repoOwner` variables in `astro.config.mjs` to silence TypeScript/Astro diagnostic warnings about unused declarations.

### Description
- Deleted the `repoName` and `repoOwner` declarations from `astro.config.mjs`, leaving `siteUrl` and the `defineConfig` export unchanged.

### Testing
- No automated tests were run after this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ef464cdd48321b90dba4e40e9fd68)